### PR TITLE
fix: add prerequisites

### DIFF
--- a/API.md
+++ b/API.md
@@ -1888,7 +1888,8 @@ const hugoPipelineAwsCdkTypeScriptAppOptions: HugoPipelineAwsCdkTypeScriptAppOpt
 | <code><a href="#@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeDevCommand">hugoThemeDevCommand</a></code> | <code>string</code> | The command to run to start the Hugo development server for the specified theme. |
 | <code><a href="#@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeGitRepo">hugoThemeGitRepo</a></code> | <code>string</code> | The URL of the Hugo theme Git repository. |
 | <code><a href="#@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeGitRepoBranch">hugoThemeGitRepoBranch</a></code> | <code>string</code> | The branch of the Hugo theme Git repository to use. |
-| <code><a href="#@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeSubmoduleStructure">hugoThemeSubmoduleStructure</a></code> | <code>string</code> | The structure of the Hugo theme submodule folder without trailing slash. |
+| <code><a href="#@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeSubmoduleExampleSiteDirectory">hugoThemeSubmoduleExampleSiteDirectory</a></code> | <code>string</code> | The directory of the Hugo theme example site below the 'blog' folder. |
+| <code><a href="#@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeSubmoduleStructure">hugoThemeSubmoduleStructure</a></code> | <code>string</code> | The structure of the Hugo theme submodule folder without trailing slash below the 'blog' folder. |
 | <code><a href="#@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.subDomain">subDomain</a></code> | <code>string</code> | The subdomain of the website to use for the development environment. |
 
 ---
@@ -4287,6 +4288,19 @@ The branch of the Hugo theme Git repository to use.
 
 ---
 
+##### `hugoThemeSubmoduleExampleSiteDirectory`<sup>Optional</sup> <a name="hugoThemeSubmoduleExampleSiteDirectory" id="@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeSubmoduleExampleSiteDirectory"></a>
+
+```typescript
+public readonly hugoThemeSubmoduleExampleSiteDirectory: string;
+```
+
+- *Type:* string
+- *Default:* themes/blist/exampleSite
+
+The directory of the Hugo theme example site below the 'blog' folder.
+
+---
+
 ##### `hugoThemeSubmoduleStructure`<sup>Optional</sup> <a name="hugoThemeSubmoduleStructure" id="@mavogel/projen-cdk-hugo-pipeline.HugoPipelineAwsCdkTypeScriptAppOptions.property.hugoThemeSubmoduleStructure"></a>
 
 ```typescript
@@ -4294,9 +4308,9 @@ public readonly hugoThemeSubmoduleStructure: string;
 ```
 
 - *Type:* string
-- *Default:* blog/themes/blist
+- *Default:* themes/blist
 
-The structure of the Hugo theme submodule folder without trailing slash.
+The structure of the Hugo theme submodule folder without trailing slash below the 'blog' folder.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ npx projen new \
     --hugoThemeGitRepoBranch='45d0f4605802d311db4a9f1288ffa8ea9f1cf689' \
     --hugoThemeSubmoduleStructure='blog' \
     --hugoThemeConfigFile='hugo.toml' \
-    --hugoThemeDevCommand='cd blog && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender' \
+    --hugoThemeDevCommand='hugo server --source blog --watch --buildFuture --cleanDestinationDir --disableFastRender' \
     --projenrc-ts \
     --no-git
 

--- a/API.md
+++ b/API.md
@@ -5,33 +5,7 @@ This is a [projen](https://github.com/projen/projen) project template to manage 
 Setup the boilerplate for a hugo blog with a CDK pipeline to deploy it to AWS :tada:
 
 ## Usage
-
-### For the AWS UG theme
-from [Kadir](https://github.com/kkeles) as a template for all AWS UGs. See here for the [repo](https://github.com/kkeles/awsug-hugo)
-
-```sh
-# 1. create a new project directory
-mkdir my-website &&  cd my-website
-
-# 2. set up the project using the projen new command
-npx projen new \
-    --from @mavogel/projen-cdk-hugo-pipeline@~0 \
-    --domain='example.com' \
-    --hugoThemeGitRepo='https://github.com/kkeles/awsug-hugo.git' \
-    --hugoThemeGitRepoBranch='45d0f4605802d311db4a9f1288ffa8ea9f1cf689' \
-    --hugoThemeSubmoduleStructure='blog' \
-    --hugoThemeConfigFile='hugo.toml' \
-    --hugoThemeDevCommand='hugo server --source blog --watch --buildFuture --cleanDestinationDir --disableFastRender' \
-    --projenrc-ts \
-    --no-git
-
-# 3. run the hugo development server
-npm run dev
-
-# 4. see if it builds correctly
-npm run build-dev
-npm run build-prod # for production
-```
+Quickly run the generator :tada:
 
 ### General
 which uses the [blist](https://github.com/apvarun/blist-hugo-theme) in `v2.1.0` by default:
@@ -60,6 +34,32 @@ npm run build # for production
 Now open your browser and go to [http://localhost:1313](http://localhost:1313) to see the the website :tada:
 
 See the [API.md](API.md) for more details and all possible configuration options.
+
+### For the AWS UG theme
+from [Kadir](https://github.com/kkeles) as a template for all AWS UGs. See here for the [repo](https://github.com/kkeles/awsug-hugo)
+
+```sh
+# 1. create a new project directory
+mkdir awsug-your-town &&  cd awsug-your-town
+
+# 2. set up the project using the projen new command
+npx projen new \
+    --from @mavogel/projen-cdk-hugo-pipeline@~0 \
+    --domain='awsug-frankfurt.de' \
+    --hugoThemeGitRepo='https://github.com/mvogel/awsug-hugo.git' \
+    --hugoThemeGitRepoBranch='feat/example-site' \
+    --hugoThemeSubmoduleStructure='themes/awsug' \
+    --hugoThemeConfigFile='hugo.toml' \
+    --projenrc-ts \
+    --no-git
+
+# 3. run the hugo development server
+npm run dev
+
+# 4. see if it builds correctly
+npm run build-dev
+npm run build-prod # for production
+```
 
 ## Configuring the themes
 You can have multiple themes, and use only one. Configure the `hugo.toml` or `config.toml` accordingly. See the setup andc configuring instructions [here](https://gohugo.io/getting-started/quick-start/).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npx projen new \
     --hugoThemeGitRepoBranch='45d0f4605802d311db4a9f1288ffa8ea9f1cf689' \
     --hugoThemeSubmoduleStructure='blog' \
     --hugoThemeConfigFile='hugo.toml' \
-    --hugoThemeDevCommand='cd blog && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender' \
+    --hugoThemeDevCommand='hugo server --source blog --watch --buildFuture --cleanDestinationDir --disableFastRender' \
     --projenrc-ts \
     --no-git
 

--- a/README.md
+++ b/README.md
@@ -5,33 +5,7 @@ This is a [projen](https://github.com/projen/projen) project template to manage 
 Setup the boilerplate for a hugo blog with a CDK pipeline to deploy it to AWS :tada:
 
 ## Usage
-
-### For the AWS UG theme
-from [Kadir](https://github.com/kkeles) as a template for all AWS UGs. See here for the [repo](https://github.com/kkeles/awsug-hugo)
-
-```sh
-# 1. create a new project directory
-mkdir my-website &&  cd my-website
-
-# 2. set up the project using the projen new command
-npx projen new \
-    --from @mavogel/projen-cdk-hugo-pipeline@~0 \
-    --domain='example.com' \
-    --hugoThemeGitRepo='https://github.com/kkeles/awsug-hugo.git' \
-    --hugoThemeGitRepoBranch='45d0f4605802d311db4a9f1288ffa8ea9f1cf689' \
-    --hugoThemeSubmoduleStructure='blog' \
-    --hugoThemeConfigFile='hugo.toml' \
-    --hugoThemeDevCommand='hugo server --source blog --watch --buildFuture --cleanDestinationDir --disableFastRender' \
-    --projenrc-ts \
-    --no-git
-
-# 3. run the hugo development server
-npm run dev
-
-# 4. see if it builds correctly
-npm run build-dev
-npm run build-prod # for production
-```
+Quickly run the generator :tada:
 
 ### General
 which uses the [blist](https://github.com/apvarun/blist-hugo-theme) in `v2.1.0` by default:
@@ -60,6 +34,32 @@ npm run build # for production
 Now open your browser and go to [http://localhost:1313](http://localhost:1313) to see the the website :tada:
 
 See the [API.md](API.md) for more details and all possible configuration options.
+
+### For the AWS UG theme
+from [Kadir](https://github.com/kkeles) as a template for all AWS UGs. See here for the [repo](https://github.com/kkeles/awsug-hugo)
+
+```sh
+# 1. create a new project directory
+mkdir awsug-your-town &&  cd awsug-your-town
+
+# 2. set up the project using the projen new command
+npx projen new \
+    --from @mavogel/projen-cdk-hugo-pipeline@~0 \
+    --domain='awsug-frankfurt.de' \
+    --hugoThemeGitRepo='https://github.com/mvogel/awsug-hugo.git' \
+    --hugoThemeGitRepoBranch='feat/example-site' \
+    --hugoThemeSubmoduleStructure='themes/awsug' \
+    --hugoThemeConfigFile='hugo.toml' \
+    --projenrc-ts \
+    --no-git
+
+# 3. run the hugo development server
+npm run dev
+
+# 4. see if it builds correctly
+npm run build-dev
+npm run build-prod # for production
+```
 
 ## Configuring the themes
 You can have multiple themes, and use only one. Configure the `hugo.toml` or `config.toml` accordingly. See the setup andc configuring instructions [here](https://gohugo.io/getting-started/quick-start/).

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
     const hugoThemeConfigFile = options.hugoThemeConfigFile || 'config.toml';
     const hugoThemeGitRepo = options.hugoThemeGitRepo || 'https://github.com/apvarun/blist-hugo-theme.git';
     const hugoThemeGitRepoBranch = options.hugoThemeGitRepoBranch || 'v2.1.0';
-    const hugoThemeDevCommand = options.hugoThemeDevCommand || `cd ${fixedHugoProjectPath} && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender`;
+    const hugoThemeDevCommand = options.hugoThemeDevCommand || `hugo server --source ${fixedHugoProjectPath} --watch --buildFuture --cleanDestinationDir --disableFastRender`;
 
     let ret = undefined;
     if (!isGitRepository(this.outdir)) {
@@ -190,8 +190,8 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
 
     // add conditional dev task to package.json
     this.package.setScript('dev', hugoThemeDevCommand);
-    this.package.setScript('build-dev', `cd ${fixedHugoProjectPath} && hugo --gc --minify --cleanDestinationDir --environment development`);
-    this.package.setScript('build-prod', `cd ${fixedHugoProjectPath} && hugo --gc --minify --cleanDestinationDir --environment production`);
+    this.package.setScript('build-dev', `hugo --source ${fixedHugoProjectPath} --gc --minify --cleanDestinationDir --environment development`);
+    this.package.setScript('build-prod', `hugo --source ${fixedHugoProjectPath} --gc --minify --cleanDestinationDir --environment production`);
 
     // add dependencies
     this.addDeps('@mavogel/cdk-hugo-pipeline');

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,19 @@ export interface HugoPipelineAwsCdkTypeScriptAppOptions
   readonly subDomain?: string;
 
   /**
-   * The structure of the Hugo theme submodule folder without trailing slash.
+   * The structure of the Hugo theme submodule folder without trailing slash below the 'blog' folder.
    *
-   * @default blog/themes/blist
+   * @default themes/blist
    *
    */
   readonly hugoThemeSubmoduleStructure?: string;
+
+  /**
+   * The directory of the Hugo theme example site below the 'blog' folder.
+   *
+   * @default themes/blist/exampleSite
+   */
+  readonly hugoThemeSubmoduleExampleSiteDirectory?: string;
 
   /**
    * The name of the Hugo theme config file.
@@ -69,13 +76,14 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
 
     // TODO fix hard coded values, such as '/blog'
     const domain = options.domain;
+    const fixedHugoProjectPath = 'blog';
     const subDomain = options.subDomain || 'dev';
-    const hugoThemeSubmoduleStructure = options.hugoThemeSubmoduleStructure || 'blog/themes/blist';
+    const hugoThemeSubmoduleStructure = options.hugoThemeSubmoduleStructure ? `${fixedHugoProjectPath}/${options.hugoThemeSubmoduleStructure}` : `${fixedHugoProjectPath}/themes/blist`;
+    const hugoThemeSubmoduleExampleSiteDirectory = options.hugoThemeSubmoduleExampleSiteDirectory ? `${fixedHugoProjectPath}/${options.hugoThemeSubmoduleExampleSiteDirectory}` : `${fixedHugoProjectPath}/themes/blist/exampleSite`;
     const hugoThemeConfigFile = options.hugoThemeConfigFile || 'config.toml';
     const hugoThemeGitRepo = options.hugoThemeGitRepo || 'https://github.com/apvarun/blist-hugo-theme.git';
     const hugoThemeGitRepoBranch = options.hugoThemeGitRepoBranch || 'v2.1.0';
-    const hugoThemeDevCommand = options.hugoThemeDevCommand || 'npm --prefix blog run start';
-
+    const hugoThemeDevCommand = options.hugoThemeDevCommand || `cd ${fixedHugoProjectPath} && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender`;
 
     let ret = undefined;
     if (!isGitRepository(this.outdir)) {
@@ -105,40 +113,40 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
       throw new Error(`Could not set branch ${hugoThemeGitRepoBranch} for git submodule ${hugoThemeGitRepo} via 'checkout' in ${this.outdir}/${hugoThemeSubmoduleStructure}`);
     }
 
+    if (!fileOrDirectoyExists(path.join(this.outdir, hugoThemeSubmoduleExampleSiteDirectory))) {
+      throw new Error(`exampleSite directory not found at '${hugoThemeSubmoduleExampleSiteDirectory}' which is a prerequisite for this projen module.`);
+    }
+
     // copy example site
     if (!lineExistsInFile(path.join(this.outdir, 'blog/config/_default/config.toml'), `theme = "${hugoThemeSubmoduleStructure.lastIndexOf('/') > 0 ? hugoThemeSubmoduleStructure.substring(hugoThemeSubmoduleStructure.lastIndexOf('/') + 1) : hugoThemeSubmoduleStructure}"`)) {
-      if (fileOrDirectoyExists(path.join(this.outdir, `${hugoThemeSubmoduleStructure}/exampleSite`))) {
-        ret = execOrUndefined(`cp -r ${this.outdir}/${hugoThemeSubmoduleStructure}/exampleSite/*  ${this.outdir}/blog/`, { cwd: this.outdir, ignoreEmptyReturnCode: true });
-        if (ret === undefined) {
-          throw new Error(`Could not copy example site from ${this.outdir}/${hugoThemeSubmoduleStructure}/exampleSite to ${this.outdir}/blog`);
-        }
-      } else {
-        console.log(`Could not find example site in ${this.outdir}/${hugoThemeSubmoduleStructure}/exampleSite. No copying`);
+      ret = execOrUndefined(`cp -r ${this.outdir}/${hugoThemeSubmoduleExampleSiteDirectory}/*  ${this.outdir}/${fixedHugoProjectPath}/`, { cwd: this.outdir, ignoreEmptyReturnCode: true });
+      if (ret === undefined) {
+        throw new Error(`Could not copy example site from ${this.outdir}/${hugoThemeSubmoduleExampleSiteDirectory} to ${this.outdir}/${fixedHugoProjectPath}`);
       }
     }
 
     // create config file structure
     // Note: no check needed as 'mkdir -p' does not throw an error if the dir already exists
-    ret = execOrUndefined('mkdir -p blog/config/_default blog/config/development blog/config/production', { cwd: this.outdir, ignoreEmptyReturnCode: true });
+    ret = execOrUndefined(`mkdir -p ${fixedHugoProjectPath}/config/_default ${fixedHugoProjectPath}/config/development ${fixedHugoProjectPath}/config/production`, { cwd: this.outdir, ignoreEmptyReturnCode: true });
     if (ret === undefined) {
-      throw new Error(`Could not create config file structure in ${this.outdir}/blog/config`);
+      throw new Error(`Could not create config file structure in ${this.outdir}/${fixedHugoProjectPath}/config`);
     }
 
-    if (!fileOrDirectoyExists(path.join(this.outdir, 'blog/config/_default/config.toml'))) {
-      ret = execOrUndefined(`mv ${this.outdir}/blog/${hugoThemeConfigFile} ${this.outdir}/blog/config/_default/config.toml`, { cwd: this.outdir, ignoreEmptyReturnCode: true });
+    if (!fileOrDirectoyExists(path.join(this.outdir, `${fixedHugoProjectPath}/config/_default/config.toml`))) {
+      ret = execOrUndefined(`mv ${this.outdir}/${fixedHugoProjectPath}/${hugoThemeConfigFile} ${this.outdir}/${fixedHugoProjectPath}/config/_default/config.toml`, { cwd: this.outdir, ignoreEmptyReturnCode: true });
       if (ret === undefined) {
-        throw new Error(`Could not move '${this.outdir}/blog/${hugoThemeConfigFile}' to '${this.outdir}/blog/config/_default/config.toml'`);
+        throw new Error(`Could not move '${this.outdir}/${fixedHugoProjectPath}/${hugoThemeConfigFile}' to '${this.outdir}/${fixedHugoProjectPath}/config/_default/config.toml'`);
       }
     }
 
-    new TextFile(this, 'blog/config/development/config.toml', {
+    new TextFile(this, `${fixedHugoProjectPath}/config/development/config.toml`, {
       lines: [
         `baseurl = "https://${subDomain}.${domain}"`,
         'publishDir = "public-development"',
       ],
     });
 
-    new TextFile(this, 'blog/config/production/config.toml', {
+    new TextFile(this, `${fixedHugoProjectPath}/config/production/config.toml`, {
       lines: [
         `baseurl = "https://${domain}"`,
         'publishDir = "public-production"',
@@ -162,8 +170,8 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
     ];
     for (const file of filesToCopyFromThemeDir) {
       // if target file exists yet
-      if (fileOrDirectoyExists(path.join(this.outdir, 'blog', file))) {
-        console.log(`Target file ${this.outdir}/blog/${file} already exists. Skipping copy from theme dir.`);
+      if (fileOrDirectoyExists(path.join(this.outdir, fixedHugoProjectPath, file))) {
+        console.log(`Target file ${this.outdir}/${fixedHugoProjectPath}/${file} already exists. Skipping copy from theme dir.`);
         continue;
       }
 
@@ -173,18 +181,17 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
         continue;
       }
 
-      ret = execOrUndefined(`cp ${hugoThemeSubmoduleStructure}/${file} blog/${file}`, { cwd: this.outdir, ignoreEmptyReturnCode: true });
+      ret = execOrUndefined(`cp ${hugoThemeSubmoduleStructure}/${file} ${fixedHugoProjectPath}/${file}`, { cwd: this.outdir, ignoreEmptyReturnCode: true });
       if (ret === undefined) {
-        throw new Error(`Could not copy ${this.outdir}/${hugoThemeSubmoduleStructure}/${file} to ${this.outdir}/blog/${file}`);
+        throw new Error(`Could not copy ${this.outdir}/${hugoThemeSubmoduleStructure}/${file} to ${this.outdir}/${fixedHugoProjectPath}/${file}`);
       }
-      console.log(`Copied ${this.outdir}/${hugoThemeSubmoduleStructure}/${file} to ${this.outdir}/blog/${file}`);
+      console.log(`Copied ${this.outdir}/${hugoThemeSubmoduleStructure}/${file} to ${this.outdir}/${fixedHugoProjectPath}/${file}`);
     }
 
     // add conditional dev task to package.json
-    const hugoThemeTopFolder = hugoThemeSubmoduleStructure.indexOf('/') > 0 ? hugoThemeSubmoduleStructure.substring(0, hugoThemeSubmoduleStructure.indexOf('/')) : hugoThemeSubmoduleStructure;
     this.package.setScript('dev', hugoThemeDevCommand);
-    this.package.setScript('build-dev', `cd ${hugoThemeTopFolder} && hugo --gc --minify --cleanDestinationDir --environment development`);
-    this.package.setScript('build-prod', `cd ${hugoThemeTopFolder} && hugo --gc --minify --cleanDestinationDir --environment production`);
+    this.package.setScript('build-dev', `cd ${fixedHugoProjectPath} && hugo --gc --minify --cleanDestinationDir --environment development`);
+    this.package.setScript('build-prod', `cd ${fixedHugoProjectPath} && hugo --gc --minify --cleanDestinationDir --environment production`);
 
     // add dependencies
     this.addDeps('@mavogel/cdk-hugo-pipeline');
@@ -194,6 +201,7 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
       new SampleCode(this, {
         domain: domain,
         subDomain: subDomain,
+        fixedHugoProjectPath: fixedHugoProjectPath,
       });
     }
   }
@@ -202,6 +210,7 @@ export class HugoPipelineAwsCdkTypeScriptApp extends AwsCdkTypeScriptApp {
 interface SampleCodeOptions {
   domain: string;
   subDomain: string;
+  fixedHugoProjectPath: string;
 }
 
 class SampleCode extends Component {
@@ -251,6 +260,7 @@ class SampleCode extends Component {
         name: '${this.normalizedHugoBlogName}',
         domainName: props.domainName,
         siteSubDomain: '${this.options.subDomain}',
+        hugoProjectPath: path.join(process.cwd(), '${this.options.fixedHugoProjectPath}'),
       });
     }
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,7 +18,7 @@ describe('configurations', () => {
   test('default all files are written', () => {
     const domain = 'example.com';
     const subDomain = 'my-sub';
-    const defaultHugoThemeDevCommand = 'cd blog && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender';
+    const defaultHugoThemeDevCommand = 'hugo server --source blog --watch --buildFuture --cleanDestinationDir --disableFastRender';
     const project = new HugoPipelineAwsCdkTypeScriptApp({
       cdkVersion: '2.0.0-rc.1',
       defaultReleaseBranch: 'main',
@@ -70,10 +70,10 @@ describe('configurations', () => {
       snap['package.json'].indexOf(`"dev": "${defaultHugoThemeDevCommand}"`),
     ).not.toEqual(-1);
     expect(
-      snap['package.json'].indexOf('"build-dev": "cd blog && hugo --gc --minify --cleanDestinationDir --environment development"'),
+      snap['package.json'].indexOf('"build-dev": "hugo --source blog --gc --minify --cleanDestinationDir --environment development"'),
     ).not.toEqual(-1);
     expect(
-      snap['package.json'].indexOf('"build-prod": "cd blog && hugo --gc --minify --cleanDestinationDir --environment production"'),
+      snap['package.json'].indexOf('"build-prod": "hugo --source blog --gc --minify --cleanDestinationDir --environment production"'),
     ).not.toEqual(-1);
   });
 
@@ -136,13 +136,13 @@ describe('configurations', () => {
       snap['blog/config/production/config.toml'].indexOf('publishDir = "public-production"'),
     ).not.toEqual(-1);
     expect(
-      snap['package.json'].indexOf('"dev": "cd blog && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender"'),
+      snap['package.json'].indexOf('"dev": "hugo server --source blog --watch --buildFuture --cleanDestinationDir --disableFastRender"'),
     ).not.toEqual(-1);
     expect(
-      snap['package.json'].indexOf('"build-dev": "cd blog && hugo --gc --minify --cleanDestinationDir --environment development"'),
+      snap['package.json'].indexOf('"build-dev": "hugo --source blog --gc --minify --cleanDestinationDir --environment development"'),
     ).not.toEqual(-1);
     expect(
-      snap['package.json'].indexOf('"build-prod": "cd blog && hugo --gc --minify --cleanDestinationDir --environment production"'),
+      snap['package.json'].indexOf('"build-prod": "hugo --source blog --gc --minify --cleanDestinationDir --environment production"'),
     ).not.toEqual(-1);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,7 +18,7 @@ describe('configurations', () => {
   test('default all files are written', () => {
     const domain = 'example.com';
     const subDomain = 'my-sub';
-    const defaultHugoThemeDevCommand = 'npm --prefix blog run start';
+    const defaultHugoThemeDevCommand = 'cd blog && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender';
     const project = new HugoPipelineAwsCdkTypeScriptApp({
       cdkVersion: '2.0.0-rc.1',
       defaultReleaseBranch: 'main',
@@ -80,23 +80,25 @@ describe('configurations', () => {
   test('awsug all files are written', () => {
     const domain = 'example.com';
     const subDomain = 'my-sub';
-    const hugoThemeDevCommand = 'cd blog && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender';
     const project = new HugoPipelineAwsCdkTypeScriptApp({
       cdkVersion: '2.0.0-rc.1',
       defaultReleaseBranch: 'main',
       name: 'test',
       domain: domain,
       subDomain: subDomain,
-      hugoThemeGitRepo: 'https://github.com/kkeles/awsug-hugo.git',
-      hugoThemeGitRepoBranch: '45d0f4605802d311db4a9f1288ffa8ea9f1cf689',
-      hugoThemeSubmoduleStructure: 'blog',
+      hugoThemeGitRepo: 'https://github.com/mavogel/awsug-hugo.git',
+      hugoThemeGitRepoBranch: 'feat/example-site',
+      hugoThemeSubmoduleStructure: 'themes/awsug',
+      hugoThemeSubmoduleExampleSiteDirectory: 'themes/awsug/exampleSite',
       hugoThemeConfigFile: 'hugo.toml',
-      hugoThemeDevCommand: hugoThemeDevCommand,
     });
     const snap = synthSnapshot(project, { parseJson: false });
     expect(snap['src/main.ts']).not.toBeUndefined();
     expect(
       snap['src/main.ts'].indexOf('@mavogel/cdk-hugo-pipeline'),
+    ).not.toEqual(-1);
+    expect(
+      snap['src/main.ts'].indexOf("hugoProjectPath: path.join(process.cwd(), 'blog'),"),
     ).not.toEqual(-1);
     expect(snap['test/main.test.ts']).not.toBeUndefined();
     expect(
@@ -104,19 +106,19 @@ describe('configurations', () => {
     ).not.toEqual(-1);
     expect(snap['.gitmodules']).not.toBeUndefined();
     expect(
-      snap['.gitmodules'].indexOf('[submodule "blog"]'),
+      snap['.gitmodules'].indexOf('[submodule "blog/themes/awsug"]'),
     ).not.toEqual(-1);
     expect(
-      snap['.gitignore'].indexOf('blog/public*'),
+      snap['.gitignore'].indexOf('blog/themes/awsug/public*'),
     ).not.toEqual(-1);
     expect(
-      snap['.gitignore'].indexOf('blog/resources/_gen'),
+      snap['.gitignore'].indexOf('blog/themes/awsug/resources/_gen'),
     ).not.toEqual(-1);
     expect(
-      snap['.gitignore'].indexOf('blog/.DS_Store'),
+      snap['.gitignore'].indexOf('blog/themes/awsug/.DS_Store'),
     ).not.toEqual(-1);
     expect(
-      snap['.gitignore'].indexOf('blog/.hugo_build.lock'),
+      snap['.gitignore'].indexOf('blog/themes/awsug/.hugo_build.lock'),
     ).not.toEqual(-1);
     expect(snap['blog/config/_default/config.toml']).not.toBeUndefined();
     expect(snap['blog/config/development/config.toml']).not.toBeUndefined();
@@ -134,7 +136,7 @@ describe('configurations', () => {
       snap['blog/config/production/config.toml'].indexOf('publishDir = "public-production"'),
     ).not.toEqual(-1);
     expect(
-      snap['package.json'].indexOf(`"dev": "${hugoThemeDevCommand}"`),
+      snap['package.json'].indexOf('"dev": "cd blog && hugo server --watch --buildFuture --cleanDestinationDir --disableFastRender"'),
     ).not.toEqual(-1);
     expect(
       snap['package.json'].indexOf('"build-dev": "cd blog && hugo --gc --minify --cleanDestinationDir --environment development"'),


### PR DESCRIPTION
- make `exampleSite` dir mandatory. No build matrix is needed, as proposed in #2. Making a constraint instead
- have `blog` fixed as top-level directory